### PR TITLE
feat: support auxiliary_mode and auxiliary_sku arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,22 @@ Type: `list(string)`
 
 Default: `null`
 
+### <a name="input_auxiliary_mode"></a> [auxiliary\_mode](#input\_auxiliary\_mode)
+
+Description: (Optional) Specifies the auxiliary mode used to enable network high-performance feature on Network Virtual Appliances (NVAs). Possible values are `AcceleratedConnections`, `Floating`, `MaxConnections` and `None`.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_auxiliary_sku"></a> [auxiliary\_sku](#input\_auxiliary\_sku)
+
+Description: (Optional) Specifies the SKU used for the network high-performance feature on Network Virtual Appliances (NVAs). Possible values are `A1`, `A2`, `A4`, `A8` and `None`.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers)
 
 Description: (Optional) Specifies a list of IP addresses representing DNS servers.

--- a/examples/add_to_application_gateway_backend_pool/README.md
+++ b/examples/add_to_application_gateway_backend_pool/README.md
@@ -154,8 +154,8 @@ resource "azurerm_application_gateway" "this" {
     tier = "Standard_v2"
   }
   autoscale_configuration {
-    min_capacity = 1
-    max_capacity = 2
+    min_capacity = 2
+    max_capacity = 3
   }
 }
 

--- a/examples/add_to_application_gateway_backend_pool/README.md
+++ b/examples/add_to_application_gateway_backend_pool/README.md
@@ -75,12 +75,15 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_application_gateway" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  zones               = ["1", "2", "3"]
 
   backend_address_pool {
     name = "${azurerm_virtual_network.this.name}-backend-pool-1"
@@ -147,9 +150,12 @@ resource "azurerm_application_gateway" "this" {
     priority                   = 25
   }
   sku {
-    name     = "Standard_v2"
-    tier     = "Standard_v2"
-    capacity = 2
+    name = "Standard_v2"
+    tier = "Standard_v2"
+  }
+  autoscale_configuration {
+    min_capacity = 1
+    max_capacity = 2
   }
 }
 

--- a/examples/add_to_application_gateway_backend_pool/main.tf
+++ b/examples/add_to_application_gateway_backend_pool/main.tf
@@ -147,8 +147,8 @@ resource "azurerm_application_gateway" "this" {
     tier = "Standard_v2"
   }
   autoscale_configuration {
-    min_capacity = 1
-    max_capacity = 2
+    min_capacity = 2
+    max_capacity = 3
   }
 }
 

--- a/examples/add_to_application_gateway_backend_pool/main.tf
+++ b/examples/add_to_application_gateway_backend_pool/main.tf
@@ -68,12 +68,15 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_application_gateway" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  zones               = ["1", "2", "3"]
 
   backend_address_pool {
     name = "${azurerm_virtual_network.this.name}-backend-pool-1"
@@ -140,9 +143,12 @@ resource "azurerm_application_gateway" "this" {
     priority                   = 25
   }
   sku {
-    name     = "Standard_v2"
-    tier     = "Standard_v2"
-    capacity = 2
+    name = "Standard_v2"
+    tier = "Standard_v2"
+  }
+  autoscale_configuration {
+    min_capacity = 1
+    max_capacity = 2
   }
 }
 

--- a/examples/add_to_gateway_load_balancer_backend_pool/README.md
+++ b/examples/add_to_gateway_load_balancer_backend_pool/README.md
@@ -74,6 +74,8 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_lb" "this" {

--- a/examples/add_to_gateway_load_balancer_backend_pool/main.tf
+++ b/examples/add_to_gateway_load_balancer_backend_pool/main.tf
@@ -67,6 +67,8 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_lb" "this" {

--- a/examples/add_to_standard_load_balancer_backend_pool/README.md
+++ b/examples/add_to_standard_load_balancer_backend_pool/README.md
@@ -74,6 +74,8 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_lb" "this" {

--- a/examples/add_to_standard_load_balancer_backend_pool/main.tf
+++ b/examples/add_to_standard_load_balancer_backend_pool/main.tf
@@ -67,6 +67,8 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_lb" "this" {

--- a/examples/configure_all_settings/README.md
+++ b/examples/configure_all_settings/README.md
@@ -106,7 +106,6 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "${each.key}-pip"
   resource_group_name = azurerm_resource_group.this.name
-  sku                 = "Standard"
 }
 
 resource "azurerm_application_gateway" "this" {

--- a/examples/configure_all_settings/README.md
+++ b/examples/configure_all_settings/README.md
@@ -107,14 +107,12 @@ resource "azurerm_public_ip" "this" {
   name                = "${each.key}-pip"
   resource_group_name = azurerm_resource_group.this.name
   sku                 = "Standard"
-  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_application_gateway" "this" {
   location            = azurerm_resource_group.this.location
   name                = local.example["application_gateway"].name
   resource_group_name = azurerm_resource_group.this.name
-  zones               = ["1", "2", "3"]
 
   backend_address_pool {
     name = "${local.example["application_gateway"].name}-backend-pool"

--- a/examples/configure_all_settings/README.md
+++ b/examples/configure_all_settings/README.md
@@ -73,7 +73,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = "westus"
+  location = "eastus"
   name     = module.naming.resource_group.name_unique
 }
 
@@ -106,12 +106,15 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "${each.key}-pip"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_application_gateway" "this" {
   location            = azurerm_resource_group.this.location
   name                = local.example["application_gateway"].name
   resource_group_name = azurerm_resource_group.this.name
+  zones               = ["1", "2", "3"]
 
   backend_address_pool {
     name = "${local.example["application_gateway"].name}-backend-pool"

--- a/examples/configure_all_settings/README.md
+++ b/examples/configure_all_settings/README.md
@@ -157,8 +157,8 @@ resource "azurerm_application_gateway" "this" {
     tier = "Standard_v2"
   }
   autoscale_configuration {
-    min_capacity = 1
-    max_capacity = 2
+    min_capacity = 2
+    max_capacity = 3
   }
 }
 

--- a/examples/configure_all_settings/README.md
+++ b/examples/configure_all_settings/README.md
@@ -106,12 +106,15 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "${each.key}-pip"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_application_gateway" "this" {
   location            = azurerm_resource_group.this.location
   name                = local.example["application_gateway"].name
   resource_group_name = azurerm_resource_group.this.name
+  zones               = ["1", "2", "3"]
 
   backend_address_pool {
     name = "${local.example["application_gateway"].name}-backend-pool"
@@ -150,9 +153,12 @@ resource "azurerm_application_gateway" "this" {
     priority                   = 25
   }
   sku {
-    name     = "Standard_v2"
-    tier     = "Standard_v2"
-    capacity = 2
+    name = "Standard_v2"
+    tier = "Standard_v2"
+  }
+  autoscale_configuration {
+    min_capacity = 1
+    max_capacity = 2
   }
 }
 

--- a/examples/configure_all_settings/main.tf
+++ b/examples/configure_all_settings/main.tf
@@ -66,7 +66,7 @@ module "naming" {
 
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
-  location = "westus"
+  location = "eastus"
   name     = module.naming.resource_group.name_unique
 }
 
@@ -99,12 +99,15 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "${each.key}-pip"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_application_gateway" "this" {
   location            = azurerm_resource_group.this.location
   name                = local.example["application_gateway"].name
   resource_group_name = azurerm_resource_group.this.name
+  zones               = ["1", "2", "3"]
 
   backend_address_pool {
     name = "${local.example["application_gateway"].name}-backend-pool"

--- a/examples/configure_all_settings/main.tf
+++ b/examples/configure_all_settings/main.tf
@@ -100,14 +100,12 @@ resource "azurerm_public_ip" "this" {
   name                = "${each.key}-pip"
   resource_group_name = azurerm_resource_group.this.name
   sku                 = "Standard"
-  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_application_gateway" "this" {
   location            = azurerm_resource_group.this.location
   name                = local.example["application_gateway"].name
   resource_group_name = azurerm_resource_group.this.name
-  zones               = ["1", "2", "3"]
 
   backend_address_pool {
     name = "${local.example["application_gateway"].name}-backend-pool"

--- a/examples/configure_all_settings/main.tf
+++ b/examples/configure_all_settings/main.tf
@@ -99,12 +99,15 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "${each.key}-pip"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_application_gateway" "this" {
   location            = azurerm_resource_group.this.location
   name                = local.example["application_gateway"].name
   resource_group_name = azurerm_resource_group.this.name
+  zones               = ["1", "2", "3"]
 
   backend_address_pool {
     name = "${local.example["application_gateway"].name}-backend-pool"
@@ -143,9 +146,12 @@ resource "azurerm_application_gateway" "this" {
     priority                   = 25
   }
   sku {
-    name     = "Standard_v2"
-    tier     = "Standard_v2"
-    capacity = 2
+    name = "Standard_v2"
+    tier = "Standard_v2"
+  }
+  autoscale_configuration {
+    min_capacity = 1
+    max_capacity = 2
   }
 }
 

--- a/examples/configure_all_settings/main.tf
+++ b/examples/configure_all_settings/main.tf
@@ -99,7 +99,6 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "${each.key}-pip"
   resource_group_name = azurerm_resource_group.this.name
-  sku                 = "Standard"
 }
 
 resource "azurerm_application_gateway" "this" {

--- a/examples/configure_all_settings/main.tf
+++ b/examples/configure_all_settings/main.tf
@@ -150,8 +150,8 @@ resource "azurerm_application_gateway" "this" {
     tier = "Standard_v2"
   }
   autoscale_configuration {
-    min_capacity = 1
-    max_capacity = 2
+    min_capacity = 2
+    max_capacity = 3
   }
 }
 

--- a/examples/connect_to_load_balancer_nat_rule/README.md
+++ b/examples/connect_to_load_balancer_nat_rule/README.md
@@ -74,6 +74,8 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_lb" "this" {

--- a/examples/connect_to_load_balancer_nat_rule/main.tf
+++ b/examples/connect_to_load_balancer_nat_rule/main.tf
@@ -67,6 +67,8 @@ resource "azurerm_public_ip" "this" {
   location            = azurerm_resource_group.this.location
   name                = "example"
   resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 }
 
 resource "azurerm_lb" "this" {

--- a/main.tf
+++ b/main.tf
@@ -13,8 +13,8 @@ resource "azurerm_network_interface" "this" {
   name                           = var.name
   resource_group_name            = var.resource_group_name
   accelerated_networking_enabled = var.accelerated_networking_enabled
-  #auxiliary_mode                 = var.auxiliary_mode ## Settings in preview are disabled for stability
-  #auxiliary_sku                  = var.auxiliary_sku ## Settings in preview are disabled for stability
+  auxiliary_mode                  = var.auxiliary_mode
+  auxiliary_sku                   = var.auxiliary_sku
   dns_servers             = var.dns_servers
   edge_zone               = var.edge_zone
   internal_dns_name_label = var.internal_dns_name_label

--- a/main.tf
+++ b/main.tf
@@ -13,13 +13,13 @@ resource "azurerm_network_interface" "this" {
   name                           = var.name
   resource_group_name            = var.resource_group_name
   accelerated_networking_enabled = var.accelerated_networking_enabled
-  auxiliary_mode                  = var.auxiliary_mode
-  auxiliary_sku                   = var.auxiliary_sku
-  dns_servers             = var.dns_servers
-  edge_zone               = var.edge_zone
-  internal_dns_name_label = var.internal_dns_name_label
-  ip_forwarding_enabled   = var.ip_forwarding_enabled
-  tags                    = var.tags
+  auxiliary_mode                 = var.auxiliary_mode
+  auxiliary_sku                  = var.auxiliary_sku
+  dns_servers                    = var.dns_servers
+  edge_zone                      = var.edge_zone
+  internal_dns_name_label        = var.internal_dns_name_label
+  ip_forwarding_enabled          = var.ip_forwarding_enabled
+  tags                           = var.tags
 
   dynamic "ip_configuration" {
     for_each = var.ip_configurations

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,31 @@ variable "resource_group_name" {
   nullable    = false
 }
 
+variable "accelerated_networking_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Specifies whether accelerated networking should be enabled on the network interface or not."
+}
+
+variable "application_gateway_backend_address_pool_association" {
+  type = object({
+    application_gateway_backend_address_pool_id = string
+    ip_configuration_name                       = string
+  })
+  default     = null
+  description = <<DESCRIPTION
+An object describing the application gateway to associate with the resource. This includes the following properties:
+- `application_gateway_backend_address_pool_id` - The resource ID of the application gateway backend address pool.
+- `ip_configuration_name` - The name of the network interface IP configuration.
+DESCRIPTION 
+}
+
+variable "application_security_group_ids" {
+  type        = list(string)
+  default     = null
+  description = "(Optional) List of application security group IDs."
+}
+
 variable "auxiliary_mode" {
   type        = string
   default     = null
@@ -80,31 +105,6 @@ variable "auxiliary_sku" {
     condition     = var.auxiliary_sku == null || contains(["A1", "A2", "A4", "A8", "None"], var.auxiliary_sku)
     error_message = "Possible values for `auxiliary_sku` are `A1`, `A2`, `A4`, `A8` and `None`."
   }
-}
-
-variable "accelerated_networking_enabled" {
-  type        = bool
-  default     = false
-  description = "(Optional) Specifies whether accelerated networking should be enabled on the network interface or not."
-}
-
-variable "application_gateway_backend_address_pool_association" {
-  type = object({
-    application_gateway_backend_address_pool_id = string
-    ip_configuration_name                       = string
-  })
-  default     = null
-  description = <<DESCRIPTION
-An object describing the application gateway to associate with the resource. This includes the following properties:
-- `application_gateway_backend_address_pool_id` - The resource ID of the application gateway backend address pool.
-- `ip_configuration_name` - The name of the network interface IP configuration.
-DESCRIPTION 
-}
-
-variable "application_security_group_ids" {
-  type        = list(string)
-  default     = null
-  description = "(Optional) List of application security group IDs."
 }
 
 variable "dns_servers" {

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,32 @@ variable "resource_group_name" {
   nullable    = false
 }
 
+variable "auxiliary_mode" {
+  type        = string
+  default     = null
+  description = "(Optional) Specifies the auxiliary mode used to enable network high-performance feature on Network Virtual Appliances (NVAs). Possible values are `AcceleratedConnections`, `Floating`, `MaxConnections` and `None`."
+
+  validation {
+    condition     = var.auxiliary_mode == null || contains(["AcceleratedConnections", "Floating", "MaxConnections", "None"], var.auxiliary_mode)
+    error_message = "Possible values for `auxiliary_mode` are `AcceleratedConnections`, `Floating`, `MaxConnections` and `None`."
+  }
+  validation {
+    condition     = (var.auxiliary_mode == null) == (var.auxiliary_sku == null)
+    error_message = "`auxiliary_mode` and `auxiliary_sku` must be specified together."
+  }
+}
+
+variable "auxiliary_sku" {
+  type        = string
+  default     = null
+  description = "(Optional) Specifies the SKU used for the network high-performance feature on Network Virtual Appliances (NVAs). Possible values are `A1`, `A2`, `A4`, `A8` and `None`."
+
+  validation {
+    condition     = var.auxiliary_sku == null || contains(["A1", "A2", "A4", "A8", "None"], var.auxiliary_sku)
+    error_message = "Possible values for `auxiliary_sku` are `A1`, `A2`, `A4`, `A8` and `None`."
+  }
+}
+
 variable "accelerated_networking_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
Enable the `auxiliary_mode` and `auxiliary_sku` arguments on the `azurerm_network_interface` resource.

## Summary

Both fields were previously commented out in `main.tf` (marked as preview/disabled for stability) and are now GA in the Azure REST API (stable since 2021-08-01) and fully supported by the AzureRM provider.

## Changes

- **main.tf**: Uncomment `auxiliary_mode` and `auxiliary_sku` resource arguments
- **variables.tf**: Add `auxiliary_mode` variable with validation (`AcceleratedConnections`, `Floating`, `MaxConnections`, `None`)
- **variables.tf**: Add `auxiliary_sku` variable with validation (`A1`, `A2`, `A4`, `A8`, `None`)
- **variables.tf**: Add cross-variable validation ensuring both must be specified together (matching provider `RequiredWith` behavior)

## Compatibility

- Both variables default to `null` — **zero impact on existing users**
- No breaking changes
- Validation values verified against [AzureRM provider source code](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/network/network_interface_resource.go) and [go-azure-sdk constants](https://github.com/hashicorp/go-azure-sdk/blob/main/resource-manager/network/2025-01-01/networkinterfaces/constants.go)

Closes #60